### PR TITLE
Refactoring: 시맨틱 태그 및 웹 접근성 고려

### DIFF
--- a/src/PAGE/Home.jsx
+++ b/src/PAGE/Home.jsx
@@ -6,9 +6,9 @@ import HomeContainer from "../components/home/HomeContainer";
 const Home = () => {
   return (
     <>
+      <Navbar />
       <HomeHeader />
       <HomeContainer />
-      <Navbar />
     </>
   );
 };

--- a/src/PAGE/Information.jsx
+++ b/src/PAGE/Information.jsx
@@ -7,9 +7,9 @@ import Navbar from "../components/common/Navbar";
 const InforMation = () => {
   return (
     <>
-      <InformationHeader />
-      <InformationContainer/>
       <Navbar />
+      <InformationHeader />
+      <InformationContainer />
     </>
   )
 };

--- a/src/PAGE/Profile.jsx
+++ b/src/PAGE/Profile.jsx
@@ -8,13 +8,13 @@ import GalleryContainer from "../components/profile/GalleryContainer";
 const Profile = () => {
   return (
     <>
+      <Navbar />
       <CommonHeader />
       <main className="main">
         <ProfileContainer />
         <ProductContainer />
         <GalleryContainer />
       </main>
-      <Navbar />
     </>
   );
 };

--- a/src/PAGE/Search.jsx
+++ b/src/PAGE/Search.jsx
@@ -7,9 +7,9 @@ const Search = () => {
   const [searchUser, setSearchUsers] = useState([]);
   return (
     <>
+      <Navbar />
       <SearchBar setSearchUsers={setSearchUsers} />
       <SearchContainer SearchUser={searchUser} />
-      <Navbar />
     </>
   );
 };

--- a/src/components/PostUpload/index.jsx
+++ b/src/components/PostUpload/index.jsx
@@ -112,8 +112,8 @@ const PostUploadForm = () => {
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
-      <h3 className="textHidden">게시글 작성 페이지</h3>
       <PostFieldSet>
+        <legend className="textHidden">게시글 작성 페이지</legend>
         <ProfileImage
           onError={e => {
             trigger(e);

--- a/src/components/PostUpload/index.jsx
+++ b/src/components/PostUpload/index.jsx
@@ -140,9 +140,9 @@ const PostUploadForm = () => {
             <UploadImgIcon onChange={onChange} htmlFor="profileImg">
               <UploadImgInput
                 type="file"
-                accept="image/jpg,image/png,image/jpeg,image/gif"
                 name="profileImg"
                 id="profileImg"
+                accept="image/jpg,image/png,image/jpeg,image/gif"
                 {...register("profileImg")}
               />
             </UploadImgIcon>

--- a/src/components/PostUpload/index.jsx
+++ b/src/components/PostUpload/index.jsx
@@ -8,7 +8,7 @@ import { getUserProfile } from "../../actions/userActions";
 import basicImg from "../../asset/basic-profile-img.svg";
 import {
   Form,
-  MainFieldSet,
+  PostFieldSet,
   ProfileImage,
   PostForm,
   PostFormContainer,
@@ -112,7 +112,8 @@ const PostUploadForm = () => {
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
-      <MainFieldSet>
+      <h3 className="textHidden">게시글 작성 페이지</h3>
+      <PostFieldSet>
         <ProfileImage
           onError={e => {
             trigger(e);
@@ -123,6 +124,7 @@ const PostUploadForm = () => {
           {...register("postText", { required: true })}
           htmlFor="postText"
         >
+          <h4 className="textHidden">게시글 작성하기</h4>
           <textarea
             type="text"
             name="postText"
@@ -134,6 +136,7 @@ const PostUploadForm = () => {
             spellCheck="false"
           />
           <PostFormContainer>
+            <h4 className="textHidden">게시글 이미지 업로드</h4>
             <UploadImgIcon onChange={onChange} htmlFor="profileImg">
               <UploadImgInput
                 type="file"
@@ -166,7 +169,7 @@ const PostUploadForm = () => {
             업로드
           </UploadBtn>
         </PostForm>
-      </MainFieldSet>
+      </PostFieldSet>
     </Form>
   );
 };

--- a/src/components/PostUpload/index.style.js
+++ b/src/components/PostUpload/index.style.js
@@ -7,7 +7,7 @@ export const Form = styled.form`
   box-sizing: border-box;
 `;
 
-export const MainFieldSet = styled.fieldset`
+export const PostFieldSet = styled.fieldset`
   margin: 30px 16px;
   display: flex;
 `;
@@ -23,7 +23,7 @@ export const ProfileImage = styled.img.attrs(props => ({
   border: 0.5px solid ${props => props.theme.palette["border"]};
 `;
 
-export const PostForm = styled.div`
+export const PostForm = styled.article`
   width: 100%;
   margin-bottom: 16px;
   font-weight: 400;
@@ -35,11 +35,11 @@ export const PostForm = styled.div`
   }
 `;
 
-export const PostFormContainer = styled.div`
+export const PostFormContainer = styled.section`
   width: 100%;
   padding-top: 12px;
   overflow-x: scroll;
-  overflow: hidden;
+  overflow-y: hidden;
 `;
 
 export const UploadImgInput = styled.input`
@@ -67,14 +67,21 @@ export const UploadImgIcon = styled.label`
 
 export const PhotoList = styled.ul`
   display: flex;
-  width: 100%;
-  gap: 8px;
+  gap: 12px;
   overflow-x: scroll;
   overflow-y: hidden;
 
-  @media only screen and (max-width: 749px) {
+  &::-webkit-scrollbar {
+    height: 8px;
+  }
+  &:hover::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background: rgba(0, 0, 0, 0.3);
+  }
+  @media only screen and (max-width: 750px) {
     max-width: 390px;
   }
+
 `;
 
 export const PostImage = styled.img`
@@ -86,11 +93,13 @@ export const PostImage = styled.img`
 export const Item = styled.li`
   position: relative;
   border-radius: 10px;
+  min-width: 304px;
   width: 304px;
   height: 228px;
   overflow: hidden;
   border: 0.5px solid ${props => props.theme.palette["border"]};
   margin-right: 5px;
+  box-sizing: border-box;
 `;
 
 export const UploadBtn = styled.button`
@@ -109,7 +118,6 @@ export const UploadBtn = styled.button`
   z-index: 150;
   :disabled {
     background: ${props => {
-      /* console.log(props); */
       return props.theme.palette["lightMain"];
     }};
   }

--- a/src/components/PostView/CommentCard/index.jsx
+++ b/src/components/PostView/CommentCard/index.jsx
@@ -5,7 +5,7 @@ import {
   getCommentList,
   deleteComment,
   commentCreateAction,
-  
+
 } from "../../../actions/commentAction";
 import { getUserProfile } from "../../../actions/userActions"
 import { getWhichUserAccountName } from "../../../util/getWhichUser";
@@ -44,9 +44,9 @@ const CommentCard = ({ postId }) => {
   useEffect(() => {
     dispatch(getCommentList(postId));
   }, [dispatch, postId, craeteCommentId, deleteCommentId]);
-  
+
   const accountnameFromParams = getWhichUserAccountName();
-  
+
   useEffect(() => {
     dispatch(getUserProfile("sweetpotato"));
   }, [dispatch]);
@@ -96,11 +96,12 @@ const CommentCard = ({ postId }) => {
           autocomplete="new-password"
         >
           <ProfileLinkImg src={image || basicImg} alt="프로필" />
-          <SubmitChatLabel>
+          <SubmitChatLabel htmlFor="comment">
             <span className="textHidden">댓글 입력하기</span>
             <SubmitChatInput
-              name="comment"
               type="text"
+              name="comment"
+              id="comment"
               placeholder="댓글 입력하기"
               autoComplete="off"
               {...register("comment")}

--- a/src/components/ProductUpload/index.jsx
+++ b/src/components/ProductUpload/index.jsx
@@ -76,9 +76,9 @@ const ProductUploadForm = () => {
             />
             <input
               type="file"
-              accept="image/jpg,image/png,image/jpeg,image/gif"
               name="itemImage"
               id="itemImage"
+              accept="image/jpg,image/png,image/jpeg,image/gif"
               className="ir"
               {...register("itemImage", { required: true })}
             ></input>
@@ -108,9 +108,9 @@ const ProductUploadForm = () => {
 
           <label htmlFor="price">가격</label>
           <input
+            type="text"
             name="price"
             id="price"
-            type="text"
             placeholder="숫자만 입력 가능합니다."
             autoComplete="off"
             spellCheck="false"
@@ -127,9 +127,9 @@ const ProductUploadForm = () => {
           {errors.price?.type === "pattern" && <p>*숫자만 입력 가능합니다.</p>}
           <label htmlFor="link">판매 링크</label>
           <input
+            type="text"
             name="link"
             id="link"
-            type="text"
             placeholder="URL을 입력해 주세요."
             autoComplete="off"
             spellCheck="false"

--- a/src/components/ProductUpload/index.jsx
+++ b/src/components/ProductUpload/index.jsx
@@ -5,7 +5,7 @@ import { imageUploadsHandler } from "../../util/imageUploads";
 import { createProduct } from "../../actions/productActions";
 import {
   Form,
-  MainFieldSet,
+  ProductUploadFieldSet,
   ProductFormWrapper,
   SubTitle,
   Label,
@@ -63,7 +63,8 @@ const ProductUploadForm = () => {
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
-      <MainFieldSet>
+      <h2 className="textHidden">상품 정보 입력창</h2>
+      <ProductUploadFieldSet>
         <SubTitle>이미지 업로드</SubTitle>
         <ProductFormWrapper>
           <Label onChange={previewImage} htmlFor="itemImage">
@@ -84,9 +85,10 @@ const ProductUploadForm = () => {
           </Label>
         </ProductFormWrapper>
         <ProductFormWrapper>
-          <label>상품명</label>
+          <label htmlFor="itemName">상품명</label>
           <input
             name="itemName"
+            id="itemName"
             type="text"
             placeholder="2~10자 이내여야 합니다."
             autoComplete="off"
@@ -104,9 +106,10 @@ const ProductUploadForm = () => {
             <p>*2~10자 이내여야 합니다.</p>
           )}
 
-          <label>가격</label>
+          <label htmlFor="price">가격</label>
           <input
             name="price"
+            id="price"
             type="text"
             placeholder="숫자만 입력 가능합니다."
             autoComplete="off"
@@ -122,9 +125,10 @@ const ProductUploadForm = () => {
             })}
           />
           {errors.price?.type === "pattern" && <p>*숫자만 입력 가능합니다.</p>}
-          <label>판매 링크</label>
+          <label htmlFor="link">판매 링크</label>
           <input
             name="link"
+            id="link"
             type="text"
             placeholder="URL을 입력해 주세요."
             autoComplete="off"
@@ -142,7 +146,7 @@ const ProductUploadForm = () => {
         <UploadBtn type="submit" disabled={!isValid}>
           저장
         </UploadBtn>
-      </MainFieldSet>
+      </ProductUploadFieldSet>
     </Form>
   );
 };

--- a/src/components/ProductUpload/index.jsx
+++ b/src/components/ProductUpload/index.jsx
@@ -63,8 +63,8 @@ const ProductUploadForm = () => {
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
-      <h2 className="textHidden">상품 정보 입력창</h2>
       <ProductUploadFieldSet>
+        <legend className="textHidden">상품 정보 입력창</legend>
         <SubTitle>이미지 업로드</SubTitle>
         <ProductFormWrapper>
           <Label onChange={previewImage} htmlFor="itemImage">

--- a/src/components/ProductUpload/index.style.js
+++ b/src/components/ProductUpload/index.style.js
@@ -5,7 +5,7 @@ export const Form = styled.form`
   box-sizing: border-box;
 `;
 
-export const MainFieldSet = styled.fieldset`
+export const ProductUploadFieldSet = styled.fieldset`
   margin: 30px auto;
   max-width: 322px;
   width: 100%;
@@ -14,6 +14,7 @@ export const MainFieldSet = styled.fieldset`
 export const ProductFormWrapper = styled.div`
   margin: 0 auto 30px;
   label {
+    margin-top: 30px;
     display: block;
     color: ${props => props.theme.palette["subText"]};
     font-weight: 500;

--- a/src/components/Upload/EditPage/index.jsx
+++ b/src/components/Upload/EditPage/index.jsx
@@ -112,6 +112,7 @@ const PostUpload = () => {
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
       <MainFieldSet>
+        <legend className="textHidden">게시글 작성</legend>
         <ProfileImage
           onError={e => {
             trigger(e);

--- a/src/components/Upload/ProductPage/index.jsx
+++ b/src/components/Upload/ProductPage/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 // import { useHistory } from "react-router-dom";
-import {Form, MainFieldSet, ProductFormWrapper, SubTitle, Label, UploadBtn} from "./index.style";
+import { Form, MainFieldSet, ProductFormWrapper, SubTitle, Label, UploadBtn } from "./index.style";
 
 // 비즈니스 로직
 import { useDispatch } from "react-redux";
@@ -46,23 +46,23 @@ const ProductEditPage = () => {
   };
 
   // 3자리 마다 콤마
-//   const { getValues } = useForm({
-//     mode: 'all',
-// });
+  //   const { getValues } = useForm({
+  //     mode: 'all',
+  // });
 
-//   const [num, setNum] = useState('');
+  //   const [num, setNum] = useState('');
 
-//   const inputPriceFormat = (str) => {
-//     const comma = (str) => {
-//       str = String(str);
-//       return str.replace(/(\d)(?=(?:\d{3})+(?!\d))/g, "$1,");
-//     };
-//     const uncomma = (str) => {
-//       str = String(str);
-//       return str.replace(/[^\d]+/g, "");
-//     };
-//     return comma(uncomma(str));
-//   };
+  //   const inputPriceFormat = (str) => {
+  //     const comma = (str) => {
+  //       str = String(str);
+  //       return str.replace(/(\d)(?=(?:\d{3})+(?!\d))/g, "$1,");
+  //     };
+  //     const uncomma = (str) => {
+  //       str = String(str);
+  //       return str.replace(/[^\d]+/g, "");
+  //     };
+  //     return comma(uncomma(str));
+  //   };
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
@@ -82,51 +82,52 @@ const ProductEditPage = () => {
               name="itemImage"
               id="itemImage"
               className="ir"
-              {...register("itemImage", {required: true})}
+              {...register("itemImage", { required: true })}
             ></input>
           </Label>
         </ProductFormWrapper>
         <ProductFormWrapper>
-          <label>상품명</label>
+          <label htmlFor="itemName">상품명</label>
           <input
-            name="itemName"
             type="text"
+            name="itemName"
+            id="itemName"
             placeholder="2~10자 이내여야 합니다."
             autoComplete="off"
             spellCheck="false"
-            {...register("itemName", {required: true, minLength: 2, maxLength: 10,})}
+            {...register("itemName", { required: true, minLength: 2, maxLength: 10, })}
           />
-          {errors.itemName?.type ==="minLength" && (<p>*2~10자 이내여야 합니다.</p>)}
-          {errors.itemName?.type ==="maxLength" && (<p>*2~10자 이내여야 합니다.</p>)}
-          <label>가격</label>
+          {errors.itemName?.type === "minLength" && (<p>*2~10자 이내여야 합니다.</p>)}
+          {errors.itemName?.type === "maxLength" && (<p>*2~10자 이내여야 합니다.</p>)}
+          <label htmlFor="price">가격</label>
           <input
-            name="price"
             type="text"
-            // value={num}
-            // onChange={(e) => setNum(inputPriceFormat(e.target.value))}
+            name="price"
+            id="price"
             placeholder="숫자만 입력 가능합니다."
             autoComplete="off"
             spellCheck="false"
-            {...register("price", {required: true, pattern: /^[0-9]*$/})}
+            {...register("price", { required: true, pattern: /^[0-9]*$/ })}
           />
           {errors.price?.type === "pattern" && (<p>*숫자만 입력 가능합니다.</p>)}
-          <label>판매 링크</label>
+          <label htmlFor="link">판매 링크</label>
           <input
-            name="link"
             type="text"
+            name="link"
+            id="link"
             placeholder="URL을 입력해 주세요."
             autoComplete="off"
             spellCheck="false"
-            {...register("link", {required: true})}
+            {...register("link", { required: true })}
           />
         </ProductFormWrapper>
-        <UploadBtn 
+        <UploadBtn
           type="submit"
           onClick={nextPageHandler}
           isValid={isValid}
-          >
-            저장
-          </UploadBtn>
+        >
+          저장
+        </UploadBtn>
       </MainFieldSet>
     </Form>
   );

--- a/src/components/Upload/ProductPage/index.jsx
+++ b/src/components/Upload/ProductPage/index.jsx
@@ -67,6 +67,7 @@ const ProductEditPage = () => {
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
       <MainFieldSet>
+        <legend className="textHidden">상품 정보 입력창</legend>
         <SubTitle>이미지 업로드</SubTitle>
         <ProductFormWrapper>
           <Label onChange={previewImage} htmlFor="itemImage">

--- a/src/components/common/PostCard/index.jsx
+++ b/src/components/common/PostCard/index.jsx
@@ -79,7 +79,7 @@ function PostCard({
         <CardContentText>{content}</CardContentText>
         <CardImageContainer>
           <CardImageList>
-            {postImages.map(img => (
+            {postImages && postImages.map(img => (
               <CardImageItem key={img}>
                 <CardImage
                   src={img}

--- a/src/components/common/PostCard/index.style.js
+++ b/src/components/common/PostCard/index.style.js
@@ -56,8 +56,8 @@ export const CardAthorId = styled.span`
 
 export const CardContentContainer = styled.section`
   padding-left: 54px;
-  cursor: pointer;
 `;
+
 export const CardContentText = styled.p`
   font-weight: 400;
   font-size: 14px;
@@ -76,6 +76,7 @@ export const CardImageContainer = styled.div`
 export const CardImageList = styled.ul`
   display: flex;
   transition: all 0.4s;
+  cursor: pointer;
 `;
 
 export const CardImageItem = styled.li`

--- a/src/components/common/PostCard/index.style.js
+++ b/src/components/common/PostCard/index.style.js
@@ -42,6 +42,7 @@ export const CardAthorName = styled.span`
   line-height: 18px;
   margin-bottom: 2px;
 `;
+
 export const CardAthorId = styled.span`
   font-weight: 400;
   font-size: 12px;

--- a/src/components/common/PostIconBox/index.style.js
+++ b/src/components/common/PostIconBox/index.style.js
@@ -14,7 +14,7 @@ export const LayOut = styled.div`
 export const ActiveLikeButton = styled.button`
   display: flex;
   align-items: center;
-  color: #767676;
+  color: ${props => props.theme.palette["subText"]};
   margin-right: 18px;
   background-color: inherit;
   padding: 0;
@@ -32,7 +32,7 @@ export const ActiveLikeButton = styled.button`
 export const NotActiveLikeButton = styled.button`
   display: flex;
   align-items: center;
-  color: #767676;
+  color: ${props => props.theme.palette["subText"]};
   margin-right: 18px;
   background-color: inherit;
   padding: 0;
@@ -52,10 +52,9 @@ export const LikeCount = styled.span``;
 export const CommentButton = styled.a`
   display: flex;
   align-items: center;
-  color: #767676;
+  color: ${props => props.theme.palette["subText"]};
 
   &::before {
-    cursor: pointer;
     display: block;
     content: "";
     width: 20px;

--- a/src/components/header/InformationHeader/index.jsx
+++ b/src/components/header/InformationHeader/index.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { useHistory } from "react-router-dom";
-import { InformationLayOut, InformationWrap, PrevBtn, HeaderTitle } from "./index.style";
+import { Link, useHistory } from "react-router-dom";
+import { InformationLayOut, PrevBtn, HeaderTitle } from "./index.style";
 import PrevIcon from "../../../asset/icon-arrow-left.svg";
 
 function FollowHeader({ following }) {
@@ -11,7 +11,7 @@ function FollowHeader({ following }) {
         <img src={PrevIcon} alt="이전 페이지 버튼" />
       </PrevBtn>
       <HeaderTitle>
-        어스마켓 소식
+        <Link to="/information">어스마켓 소식</Link>
       </HeaderTitle>
     </InformationLayOut>
   );

--- a/src/components/header/InformationHeader/index.style.js
+++ b/src/components/header/InformationHeader/index.style.js
@@ -23,4 +23,5 @@ export const PrevBtn = styled.button`
 export const HeaderTitle = styled.h2`
   margin-left: 8px;
   font-size: 18px;
+  font-weight: 500;
 `;

--- a/src/components/information/InformationCard/index.jsx
+++ b/src/components/information/InformationCard/index.jsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { InformationItem, InformationWrapper, InformationLink, InformationImg, InformationInfoWrapper, InformationTitle, InformationInfo, InformationDate } from "./index.style.js"
+import { InformationItem, InformationWrapper, InformationLink, InformationImg, InformationInfoWrapper, InformationTitle, InformationText, InformationInfo, InformationDate } from "./index.style.js"
 import basicImg from "../../../asset/upload_bg.svg";
 
 
-function InformationCard({ Link, newsimage, newstitle, newsdate }) {
+function InformationCard({ Link, newsimage, newstitle, newstext, newsdate }) {
   const trigger = e => {
     e.target.src = basicImg;
   };
@@ -14,9 +14,10 @@ function InformationCard({ Link, newsimage, newstitle, newsdate }) {
         <InformationLink to="/">
           <InformationImg src={newsimage} alt="소식 이미지" onError={e => trigger(e)} />
           <InformationInfoWrapper>
-            <InformationTitle>{newstitle}</InformationTitle>
             <InformationInfo>농촌진흥청</InformationInfo>
             <InformationDate>{newsdate}</InformationDate>
+            <InformationTitle>{newstitle}</InformationTitle>
+            <InformationText>{newstext}</InformationText>
           </InformationInfoWrapper>
         </InformationLink>
       </InformationWrapper>

--- a/src/components/information/InformationCard/index.style.js
+++ b/src/components/information/InformationCard/index.style.js
@@ -7,12 +7,14 @@ export const InformationItem = styled.li`
   align-items: center;
   padding: 30px 16px;
   border-bottom: 1px solid ${props => props.theme.palette["border"]};
-  cursor: pointer;
+  &:last-child {
+    border-bottom: none;
+  }
 `;
 
 export const InformationWrapper = styled.article`
+  max-width: 800px;
   width: 100%;
-  max-width: 450px;
 `;
 
 export const InformationLink = styled(Link)`
@@ -20,49 +22,60 @@ export const InformationLink = styled(Link)`
 `;
 
 export const InformationImg = styled.img`
-  width: 140px;
-  height: 90px;
+  width: 160px;
+  height: 105px;
   border-radius: 8px;
   object-fit: cover;
   background: ${props => props.theme.palette["border"]};
-  object-fit: cover;
 `;
 
 export const InformationInfoWrapper = styled.div`
-  margin-left: 15px;
-  width: calc(100% - 118px);
-  height: 100%;
-  align-self: flex-start;
-  padding-bottom: 10px;
+  width: calc(100% - 160px);
+  min-width: 275px;
+  margin-left: 20px;
 `;
 
 export const InformationInfo = styled.span`
-    font-size: 12px;
-    color: ${props => props.theme.palette["subText"]};
+  display: inline-block;
+  font-size: 12px;
+  color: ${props => props.theme.palette["main"]};
+`;
+
+export const InformationDate = styled.span`
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 13px;
+  color: ${props => props.theme.palette["main"]};
+  margin-top: 8.5px;
+  &::before {
+    content: "·";
+    margin: 0 4px;
+  }
 `;
 
 export const InformationTitle = styled.strong`
   display: block;
-  margin: 5px 0 14px;
-  line-height: 1.3;
+  margin: 5px 0 10px;
   font-size: 20px;
   font-weight: 600;
-  height: 50px;
+  line-height: 1.6;
+  white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
+  &:hover{
+    text-decoration: underline;
+    text-underline-position: under;
+    text-decoration-color: ${props => props.theme.palette["main"]};
+  }
+`;
+
+export const InformationText = styled.p`
+  font-size: 14px;
+  line-height: 1.6;
+  overflow: hidden;
+  color: ${props => props.theme.palette["subText"]};
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-`;
-
-export const InformationDate = styled.span`
-    font-size: 12px;
-    font-weight: 400;
-    line-height: 13px;
-    color: ${props => props.theme.palette["subText"]};
-    margin-top: 8.5px;
-    &::before {
-      content: "·";
-      margin: 0 4px;
-    }
 `;

--- a/src/components/information/InformationCard/index.style.js
+++ b/src/components/information/InformationCard/index.style.js
@@ -5,7 +5,7 @@ export const InformationItem = styled.li`
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 30px 16px;
+  padding: 30px 20px;
   border-bottom: 1px solid ${props => props.theme.palette["border"]};
   &:last-child {
     border-bottom: none;

--- a/src/components/information/InformationContainer/index.jsx
+++ b/src/components/information/InformationContainer/index.jsx
@@ -34,6 +34,7 @@ const InformationContainer = time => {
               <InformationCard
                 key={Math.random() * 100}
                 newstitle={item.children[5].value.slice(0, -1)}
+                newstext={item.children[7].value.slice(0, -1)}
                 newsimage={`http://www.nongsaro.go.kr/portal/imgView.do?atchmnflGroupEsntlCode=${item.children[0].value.slice(
                   0,
                   -1,

--- a/src/components/information/InformationContainer/index.style.js
+++ b/src/components/information/InformationContainer/index.style.js
@@ -3,11 +3,10 @@ import styled from "styled-components";
 export const InfomationWrapper = styled.main`
   display: flex;
   justify-content: center;
-  padding: 0 0 70px;
-  width: 100%;
+  align-items: center;
+  padding: 10px 0 70px;
 `;
 
 export const InfomationList = styled.ul`
-  position: relative;
   width: 100%;
 `;

--- a/src/components/productupdate/index.jsx
+++ b/src/components/productupdate/index.jsx
@@ -103,19 +103,20 @@ const ProductUpdateForm = () => {
           />
           <input
             type="file"
-            accept="image/jpg,image/png,image/jpeg,image/gif"
             name="itemImage"
             id="itemImage"
+            accept="image/jpg,image/png,image/jpeg,image/gif"
             className="ir"
             {...register("itemImage")}
           ></input>
         </Label>
       </ProductFormWrapper>
       <ProductFormWrapper>
-        <label>상품명</label>
+        <label htmlFor="itemName">상품명</label>
         <input
-          name="itemName"
           type="text"
+          name="itemName"
+          id="itemName"
           autoComplete="off"
           placeholder="2~10자 이내여야 합니다."
           {...register("itemName", {
@@ -133,10 +134,11 @@ const ProductUpdateForm = () => {
         {errors.itemName?.type === "maxLength" && (
           <p>*2~10자 이내여야 합니다.</p>
         )}
-        <label>가격</label>
+        <label htmlFor="price">가격</label>
         <input
-          name="price"
           type="text"
+          name="price"
+          id="price"
           autoComplete="off"
           placeholder="숫자만 입력 가능합니다."
           {...register("price", {
@@ -150,10 +152,11 @@ const ProductUpdateForm = () => {
           })}
         />
         {errors.price?.type === "pattern" && <p>*숫자만 입력 가능합니다.</p>}
-        <label>판매 링크</label>
+        <label htmlFor="link">판매 링크</label>
         <input
-          name="link"
           type="text"
+          name="link"
+          id="link"
           autoComplete="off"
           placeholder="URL을 입력해 주세요."
           {...register("link", {

--- a/src/components/profile/ProfileCard/index.style.js
+++ b/src/components/profile/ProfileCard/index.style.js
@@ -55,6 +55,7 @@ export const FollowerLink = styled(Link)`
   text-align: center;
   cursor: pointer;
 `;
+
 export const FollowingLink = styled(Link)`
   position: absolute;
   display: block;

--- a/src/components/profileupdate/index.jsx
+++ b/src/components/profileupdate/index.jsx
@@ -112,10 +112,11 @@ const ProfileUpdateForm = () => {
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
+      <h3 className="textHidden">프로필 수정 페이지</h3>
       <ProfileImgWrapper>
         <label onChange={previewImage} htmlFor="profileImg">
           <img
-            alt="상품 이미지"
+            alt="프로필 이미지"
             onError={event => (event.target.style.display = "none")}
             onLoad={event => (event.target.style.display = "inline-block")}
             src={updateImage ? updateImage : image}
@@ -125,14 +126,16 @@ const ProfileUpdateForm = () => {
             accept="image/jpg,image/png,image/jpeg,image/gif"
             name="profileImg"
             id="profileImg"
+            title="프로필 이미지 업로드 버튼"
             {...register("profileImg" /* { required: true } */)}
           />
         </label>
       </ProfileImgWrapper>
       <ProductFormWrapper>
-        <label>사용자 이름</label>
+        <label htmlFor="username">사용자 이름</label>
         <input
           name="username"
+          id="username"
           type="text"
           autoComplete="off"
           placeholder="2~10자 이내여야 합니다."
@@ -151,9 +154,10 @@ const ProfileUpdateForm = () => {
         {errors.username?.type === "maxLength" && (
           <p>*2~10자 이내여야 합니다.</p>
         )}
-        <label> 계정 ID</label>
+        <label htmlFor="accountname"> 계정 ID</label>
         <input
           name="accountname"
+          id="accountname"
           type="text"
           autoComplete="off"
           placeholder="숫자만 입력 가능합니다."
@@ -166,9 +170,10 @@ const ProfileUpdateForm = () => {
           <p>*영문, 숫자, 밑줄 및 마침표만 사용할 수 있습니다.</p>
         )}
         {accountIdErrorMessage && <p>{accountIdErrorMessage}</p>}
-        <label>소개</label>
+        <label htmlFor="intro">소개</label>
         <input
           name="intro"
+          id="intro"
           type="text"
           autoComplete="off"
           placeholder="자신과 판매할 상품에 대해 소개해 주세요!"

--- a/src/components/profileupdate/index.jsx
+++ b/src/components/profileupdate/index.jsx
@@ -123,9 +123,9 @@ const ProfileUpdateForm = () => {
           />
           <input
             type="file"
-            accept="image/jpg,image/png,image/jpeg,image/gif"
             name="profileImg"
             id="profileImg"
+            accept="image/jpg,image/png,image/jpeg,image/gif"
             title="프로필 이미지 업로드 버튼"
             {...register("profileImg" /* { required: true } */)}
           />
@@ -134,9 +134,9 @@ const ProfileUpdateForm = () => {
       <ProductFormWrapper>
         <label htmlFor="username">사용자 이름</label>
         <input
+          type="text"
           name="username"
           id="username"
-          type="text"
           autoComplete="off"
           placeholder="2~10자 이내여야 합니다."
           {...register("username", {
@@ -156,9 +156,9 @@ const ProfileUpdateForm = () => {
         )}
         <label htmlFor="accountname"> 계정 ID</label>
         <input
+          type="text"
           name="accountname"
           id="accountname"
-          type="text"
           autoComplete="off"
           placeholder="숫자만 입력 가능합니다."
           {...register("accountname", {
@@ -172,9 +172,9 @@ const ProfileUpdateForm = () => {
         {accountIdErrorMessage && <p>{accountIdErrorMessage}</p>}
         <label htmlFor="intro">소개</label>
         <input
+          type="text"
           name="intro"
           id="intro"
-          type="text"
           autoComplete="off"
           placeholder="자신과 판매할 상품에 대해 소개해 주세요!"
           {...register("intro", {

--- a/src/components/profileupdate/index.style.js
+++ b/src/components/profileupdate/index.style.js
@@ -8,7 +8,7 @@ export const Form = styled.form`
   width: 100%;
 `;
 
-export const ProfileImgWrapper = styled.div`
+export const ProfileImgWrapper = styled.fieldset`
   margin-bottom: 30px;
   label {
     position: relative;
@@ -59,7 +59,7 @@ export const ProfileImgWrapper = styled.div`
 //     height: 110px;
 //   `;
 
-export const ProductFormWrapper = styled.div`
+export const ProductFormWrapper = styled.fieldset`
   margin: 0 auto 16px;
 
   label {
@@ -115,5 +115,4 @@ export const UploadBtn = styled.button`
   :disabled {
     background: ${props => props.theme.palette["lightMain"]};
   }
-  /* cursor: ${props => (props.disabled === true ? "default" : "pointer")}; */
-`;
+  `;

--- a/src/components/search/SearchBar/index.jsx
+++ b/src/components/search/SearchBar/index.jsx
@@ -38,7 +38,7 @@ function SearchBar({ setSearchUsers }) {
           <PrevIcon />
         </PrevBtn>
         <SearchForm onSubmit={handleSubmit(onSubmit)}>
-          <SearchInput aria-label="search" {...register("keyword")} />
+          <SearchInput {...register("keyword")} />
         </SearchForm>
       </SearchSection>
     </SearchHeader>

--- a/src/components/search/SearchBar/index.style.js
+++ b/src/components/search/SearchBar/index.style.js
@@ -48,7 +48,8 @@ export const SearchForm = styled.form`
 export const SearchInput = styled.input.attrs({
   name: "keyword",
   type: "text",
-  placeholder: "계정검색",
+  title: "계정 검색하기",
+  placeholder: "계정 검색",
   autoComplete: "off",
 })`
   width: 100%;

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -6,6 +6,7 @@ const GlobalStyles = createGlobalStyle`
     ${reset}
     a{
         text-decoration:none;
+        cursor: pointer;
         color:inherit;
     }
     *{


### PR DESCRIPTION
### 1. Information 페이지 스타일링
- 농촌 기사 본문 API를 불러와서 일부 보여주는 작업을 했습니다.
- 제목, 텍스트에 `ellipsis`를 적용해서 반응형에 따라 말줄임이 되도록 작업했습니다.

### 2. 시맨틱 태그
- `PostUpload`, `ProfileUpdate`, `ProductUpload` 페이지 작업을 했습니다.
- 시맨틱 태그를 위해 `label`의 `forHtml`, `input`의 `id` 속성을 추가했습니다.
- `fiedset` 내에 `legend`태그를 사용해서 의미에 맞는 태그를 사용하고자 했습니다.

### 3. 웹 접근성
- 키보드 접근성을 위한 Navbar 위치 변경 및 cursor 적용했습니다.
